### PR TITLE
add basic auth for admin/products

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -1,5 +1,7 @@
 class Admin::ProductsController < ApplicationController
 
+  http_basic_authenticate_with name: ENV["ADMIN_USER_NAME"], password: ENV["ADMIN_PASSWORD"]
+
   def index
     @products = Product.order(id: :desc).all
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,6 @@ class ApplicationController < ActionController::Base
   end
   helper_method :cart_subtotal_cents
 
-
   def update_cart(new_cart)
     cookies[:cart] = {
       value: JSON.generate(new_cart),


### PR DESCRIPTION
fix security bug: admin username and password are now required to access admin/products